### PR TITLE
All MegaPack units start with full HP and EP

### DIFF
--- a/techs/megapack/factions/egypt/units/air_pyramid/air_pyramid.xml
+++ b/techs/megapack/factions/egypt/units/air_pyramid/air_pyramid.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="3"/>
-		<max-hp value="3000" regeneration="5"/>
+		<max-hp value="3000" regeneration="5" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="20"/>	
 		<armor-type value="wood"/>				

--- a/techs/megapack/factions/egypt/units/anubis_warrior/anubis_warrior.xml
+++ b/techs/megapack/factions/egypt/units/anubis_warrior/anubis_warrior.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="3"/>
-		<max-hp value="900" regeneration="2"/>
+		<max-hp value="900" regeneration="2" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="40"/>	
 		<armor-type value="metal"/>

--- a/techs/megapack/factions/egypt/units/chicken/chicken.xml
+++ b/techs/megapack/factions/egypt/units/chicken/chicken.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="1"/>
-		<max-hp value="300" regeneration="0"/>
+		<max-hp value="300" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="0"/>
 		<armor-type value="organic"/>					

--- a/techs/megapack/factions/egypt/units/desert_camp/desert_camp.xml
+++ b/techs/megapack/factions/egypt/units/desert_camp/desert_camp.xml
@@ -3,7 +3,7 @@
 	<parameters>
 		<size value="3" />
 		<height value="2" />
-		<max-hp value="6000" regeneration="0"/>
+		<max-hp value="6000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="stone"/>

--- a/techs/megapack/factions/egypt/units/farm/farm.xml
+++ b/techs/megapack/factions/egypt/units/farm/farm.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="4" />
 		<height value="2" />
-		<max-hp value="3000" regeneration="0"/>
+		<max-hp value="3000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="wood"/>				

--- a/techs/megapack/factions/egypt/units/ibis/ibis.xml
+++ b/techs/megapack/factions/egypt/units/ibis/ibis.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="1"/>
-		<max-hp value="1300" regeneration="3"/>
+		<max-hp value="1300" regeneration="3" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="10"/>	
 		<armor-type value="leather"/>

--- a/techs/megapack/factions/egypt/units/mummy/mummy.xml
+++ b/techs/megapack/factions/egypt/units/mummy/mummy.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="600" regeneration="0"/>
+		<max-hp value="600" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="10"/>	
 		<armor-type value="organic"/>

--- a/techs/megapack/factions/egypt/units/obelisk/obelisk.xml
+++ b/techs/megapack/factions/egypt/units/obelisk/obelisk.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="4" />
 		<height value="5" />
-		<max-hp value="6000" regeneration="0"/>
+		<max-hp value="6000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="wood"/>		

--- a/techs/megapack/factions/egypt/units/priest/priest.xml
+++ b/techs/megapack/factions/egypt/units/priest/priest.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="700" regeneration="0"/>
+		<max-hp value="700" regeneration="0" start-percentage="1.0" />
 		<max-ep value="500" regeneration="5"/>
 		<armor value="20"/>	
 		<armor-type value="leather"/>				

--- a/techs/megapack/factions/egypt/units/priest/priest.xml
+++ b/techs/megapack/factions/egypt/units/priest/priest.xml
@@ -5,7 +5,7 @@
 		<size value="1"/>
 		<height value="2"/>
 		<max-hp value="700" regeneration="0" start-percentage="1.0" />
-		<max-ep value="500" regeneration="5"/>
+		<max-ep value="500" regeneration="5" start-percentage="1.0" />
 		<armor value="20"/>	
 		<armor-type value="leather"/>				
 		<sight value="10"/>

--- a/techs/megapack/factions/egypt/units/pyramid/pyramid.xml
+++ b/techs/megapack/factions/egypt/units/pyramid/pyramid.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="5" />
 		<height value="2" />
-		<max-hp value="9000" regeneration="0"/>
+		<max-hp value="9000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="stone"/>				

--- a/techs/megapack/factions/egypt/units/scarab/scarab.xml
+++ b/techs/megapack/factions/egypt/units/scarab/scarab.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="1400" regeneration="5"/>
+		<max-hp value="1400" regeneration="5" start-percentage="1.0" />
 		<max-ep value="0" regeneration="0"/>
 		<armor value="23"/>	
 		<armor-type value="leather"/>

--- a/techs/megapack/factions/egypt/units/slave/slave.xml
+++ b/techs/megapack/factions/egypt/units/slave/slave.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="600" regeneration="0"/>
+		<max-hp value="600" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="0"/>
 		<armor-type value="leather"/>					

--- a/techs/megapack/factions/egypt/units/snake/snake.xml
+++ b/techs/megapack/factions/egypt/units/snake/snake.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="450" regeneration="5"/>
+		<max-hp value="450" regeneration="5" start-percentage="1.0" />
 		<max-ep value="0" regeneration="0"/>
 		<armor value="15"/>	
 		<armor-type value="leather"/>

--- a/techs/megapack/factions/egypt/units/spearman/spearman.xml
+++ b/techs/megapack/factions/egypt/units/spearman/spearman.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="530" regeneration="0"/>
+		<max-hp value="530" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="16"/>	
 		<armor-type value="leather"/>				
@@ -168,7 +168,7 @@
 			<move-skill value="charge_skill"/>
 			<attack-skill value="attack_skill"/>
 		</command>
-		
+		
 		<!--command>
 			<type value="attack_stopped"/>
 			<name value="hold_position"/>

--- a/techs/megapack/factions/egypt/units/spearthrower/spearthrower.xml
+++ b/techs/megapack/factions/egypt/units/spearthrower/spearthrower.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="3"/>
-		<max-hp value="700" regeneration="0"/>
+		<max-hp value="700" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="20"/>	
 		<armor-type value="leather"/>				

--- a/techs/megapack/factions/egypt/units/sphinx/sphinx.xml
+++ b/techs/megapack/factions/egypt/units/sphinx/sphinx.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="4"/>
 		<height value="6"/>
-		<max-hp value="7000" regeneration="0"/>
+		<max-hp value="7000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="20"/>	
 		<armor-type value="wood"/>			

--- a/techs/megapack/factions/egypt/units/temple/temple.xml
+++ b/techs/megapack/factions/egypt/units/temple/temple.xml
@@ -3,7 +3,7 @@
 	<parameters>
 		<size value="4" />
 		<height value="2" />
-		<max-hp value="6000" regeneration="0"/>
+		<max-hp value="6000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="stone"/>

--- a/techs/megapack/factions/egypt/upgrades/power_of_ra/power_of_ra.xml
+++ b/techs/megapack/factions/egypt/upgrades/power_of_ra/power_of_ra.xml
@@ -17,7 +17,7 @@
 		<unit name="ibis"/>
 		<unit name="anubis_warrior"/>
 	</effects>
-	<max-hp value="75"/>
+	<max-hp value="75" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="30"/>

--- a/techs/megapack/factions/egypt/upgrades/spear_weapons/spear_weapons.xml
+++ b/techs/megapack/factions/egypt/upgrades/spear_weapons/spear_weapons.xml
@@ -15,7 +15,7 @@
 		<unit name="spearman"/>
 		<unit name="spearthrower"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="40"/>

--- a/techs/megapack/factions/egypt/upgrades/speedup_priest_production/speedup_priest_production.xml
+++ b/techs/megapack/factions/egypt/upgrades/speedup_priest_production/speedup_priest_production.xml
@@ -13,7 +13,7 @@
 	<effects>
 		<unit name="priest"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>

--- a/techs/megapack/factions/egypt/upgrades/summon_ibis/summon_ibis.xml
+++ b/techs/megapack/factions/egypt/upgrades/summon_ibis/summon_ibis.xml
@@ -11,7 +11,7 @@
 		<resource name="wood" amount="150"/>
 	</resource-requirements>
 	<effects/>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>

--- a/techs/megapack/factions/egypt/upgrades/summon_scarab/summon_scarab.xml
+++ b/techs/megapack/factions/egypt/upgrades/summon_scarab/summon_scarab.xml
@@ -11,7 +11,7 @@
 		<resource name="wood" amount="150"/>
 	</resource-requirements>
 	<effects/>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>

--- a/techs/megapack/factions/indian/units/archer/archer.xml
+++ b/techs/megapack/factions/indian/units/archer/archer.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="3"/>
-		<max-hp value="700" regeneration="0"/>
+		<max-hp value="700" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="9"/>	
 		<armor-type value="leather"/>				

--- a/techs/megapack/factions/indian/units/axe_indian/axe_indian.xml
+++ b/techs/megapack/factions/indian/units/axe_indian/axe_indian.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="700" regeneration="0"/>
+		<max-hp value="700" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="35"/>	
 		<armor-type value="leather"/>

--- a/techs/megapack/factions/indian/units/axe_thrower/axe_thrower.xml
+++ b/techs/megapack/factions/indian/units/axe_thrower/axe_thrower.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="700" regeneration="0"/>
+		<max-hp value="700" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="20"/>	
 		<armor-type value="leather"/>

--- a/techs/megapack/factions/indian/units/beehive/beehive.xml
+++ b/techs/megapack/factions/indian/units/beehive/beehive.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="3"/>
-		<max-hp value="7000" regeneration="0"/>
+		<max-hp value="7000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="20"/>	
 		<armor-type value="wood"/>			

--- a/techs/megapack/factions/indian/units/bigtent/bigtent.xml
+++ b/techs/megapack/factions/indian/units/bigtent/bigtent.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="3" />
 		<height value="2" />
-		<max-hp value="3000" regeneration="0"/>
+		<max-hp value="3000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="stone"/>				

--- a/techs/megapack/factions/indian/units/bull/bull.xml
+++ b/techs/megapack/factions/indian/units/bull/bull.xml
@@ -6,7 +6,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="700" regeneration="4"/>
+		<max-hp value="700" regeneration="4" start-percentage="1.0" />
 		<max-ep value="500" regeneration="80"/>
 		<armor value="3"/>	
 		<armor-type value="organic"/>

--- a/techs/megapack/factions/indian/units/bull/bull.xml
+++ b/techs/megapack/factions/indian/units/bull/bull.xml
@@ -7,7 +7,7 @@
 		<size value="1"/>
 		<height value="2"/>
 		<max-hp value="700" regeneration="4" start-percentage="1.0" />
-		<max-ep value="500" regeneration="80"/>
+		<max-ep value="500" regeneration="80" start-percentage="1.0" />
 		<armor value="3"/>	
 		<armor-type value="organic"/>
 		<sight value="12"/>

--- a/techs/megapack/factions/indian/units/campfire/campfire.xml
+++ b/techs/megapack/factions/indian/units/campfire/campfire.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="3" />
 		<height value="2" />
-		<max-hp value="5400" regeneration="0"/>
+		<max-hp value="5400" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="stone"/>				

--- a/techs/megapack/factions/indian/units/fire_archer/fire_archer.xml
+++ b/techs/megapack/factions/indian/units/fire_archer/fire_archer.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="3"/>
-		<max-hp value="700" regeneration="0"/>
+		<max-hp value="700" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="15"/>	
 		<armor-type value="leather"/>				
@@ -25,7 +25,8 @@
 		<properties/>
 		<light enabled="false"/>
 		<unit-requirements>
-			<unit name="tent"/>                        <unit name="reed"/>
+			<unit name="tent"/>
+                        <unit name="reed"/>
                         <unit name="campfire"/>
 		</unit-requirements>
 		<upgrade-requirements/>

--- a/techs/megapack/factions/indian/units/firegolem/firegolem.xml
+++ b/techs/megapack/factions/indian/units/firegolem/firegolem.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="2"/>
-		<max-hp value="2000" regeneration="3"/>
+		<max-hp value="2000" regeneration="3" start-percentage="1.0" />
 		<max-ep value="0" regeneration="0"/>
 		<armor value="45"/>	
 		<armor-type value="stone"/>

--- a/techs/megapack/factions/indian/units/horsefarm/horsefarm.xml
+++ b/techs/megapack/factions/indian/units/horsefarm/horsefarm.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="4" />
 		<height value="2" />
-		<max-hp value="4000" regeneration="0"/>
+		<max-hp value="4000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="wood"/>				

--- a/techs/megapack/factions/indian/units/horseman/horseman.xml
+++ b/techs/megapack/factions/indian/units/horseman/horseman.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="2"/>
-		<max-hp value="1300" regeneration="0"/>
+		<max-hp value="1300" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="50"/>	
 		<armor-type value="leather"/>

--- a/techs/megapack/factions/indian/units/mainteepee/mainteepee.xml
+++ b/techs/megapack/factions/indian/units/mainteepee/mainteepee.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="5" />
 		<height value="2" />
-		<max-hp value="9000" regeneration="0"/>
+		<max-hp value="9000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="stone"/>				

--- a/techs/megapack/factions/indian/units/reed/reed.xml
+++ b/techs/megapack/factions/indian/units/reed/reed.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="5" />
 		<height value="2" />
-		<max-hp value="3400" regeneration="0"/>
+		<max-hp value="3400" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="stone"/>				

--- a/techs/megapack/factions/indian/units/roundtent/roundtent.xml
+++ b/techs/megapack/factions/indian/units/roundtent/roundtent.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="4" />
 		<height value="2" />
-		<max-hp value="6000" regeneration="0"/>
+		<max-hp value="6000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="stone"/>
@@ -147,7 +147,7 @@
 			<produce-skill value="produce_skill"/>
 			<produced-unit name="fire_archer"/>
 		</command>
-		<!-- *** command 5 *** -->
+		<!-- *** command 5 *** -->
 		<command>
 			<type value="produce"/>
 			<name value="produce_spearman" />
@@ -157,7 +157,7 @@
 			<produce-skill value="produce_skill"/>
 			<produced-unit name="spearman"/>
 		</command>
-		
+		
 		<!-- *** command 6 *** -->
 		<command>
 			<type value="upgrade"/>

--- a/techs/megapack/factions/indian/units/shaman/shaman.xml
+++ b/techs/megapack/factions/indian/units/shaman/shaman.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="550" regeneration="0"/>
+		<max-hp value="550" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="0"/>
 		<armor-type value="leather"/>					

--- a/techs/megapack/factions/indian/units/spearman/spearman.xml
+++ b/techs/megapack/factions/indian/units/spearman/spearman.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="700" regeneration="2"/>
+		<max-hp value="700" regeneration="2" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="10"/>	
 		<armor-type value="leather"/>
@@ -108,7 +108,12 @@
 			<attack-start-time value="0.15"/>
 			<projectile value="false">
 			</projectile>
-			<splash value="true">				<radius value="0"/>				<damage-all value="true"/>				<particle value="true" path="particle_splash.xml"/>			</splash>		</skill>
+			<splash value="true">
+				<radius value="0"/>
+				<damage-all value="true"/>
+				<particle value="true" path="particle_splash.xml"/>
+			</splash>
+		</skill>
 		
 		<skill>
 			<type value="morph"/>

--- a/techs/megapack/factions/indian/units/stickfighter/stickfighter.xml
+++ b/techs/megapack/factions/indian/units/stickfighter/stickfighter.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="700" regeneration="0"/>
+		<max-hp value="700" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="7"/>	
 		<armor-type value="leather"/>				
@@ -191,7 +191,7 @@
 			<move-skill value="charge_skill"/>
 			<attack-skill value="attack_skill"/>
 		</command>
-		
+		
 		<command>
 			<type value="attack_stopped"/>
 			<name value="hold_position"/>

--- a/techs/megapack/factions/indian/units/tent/tent.xml
+++ b/techs/megapack/factions/indian/units/tent/tent.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="3" />
 		<height value="2" />
-		<max-hp value="1400" regeneration="0"/>
+		<max-hp value="1400" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="stone"/>				

--- a/techs/megapack/factions/indian/units/thunderbird/thunderbird.xml
+++ b/techs/megapack/factions/indian/units/thunderbird/thunderbird.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="1"/>
-		<max-hp value="1300" regeneration="3"/>
+		<max-hp value="1300" regeneration="3" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="20"/>	
 		<armor-type value="organic"/>
@@ -101,7 +101,12 @@
 					<sound-file path="$COMMONDATAPATH/sounds/eagle_hit4.wav"/>
 				</sound>
 			</projectile>
-			<splash value="true">				<radius value="1"/>				<damage-all value="true"/>				<particle value="true" path="particle_splash.xml"/>			</splash>		</skill>
+			<splash value="true">
+				<radius value="1"/>
+				<damage-all value="true"/>
+				<particle value="true" path="particle_splash.xml"/>
+			</splash>
+		</skill>
 		<skill>
 			<type value="attack"/>
 			<name value="attack_skill"/>		

--- a/techs/megapack/factions/indian/units/totem/totem.xml
+++ b/techs/megapack/factions/indian/units/totem/totem.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="3" />
 		<height value="2" />
-		<max-hp value="11000" regeneration="0"/>
+		<max-hp value="11000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="wood"/>				

--- a/techs/megapack/factions/indian/units/worker/worker.xml
+++ b/techs/megapack/factions/indian/units/worker/worker.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="600" regeneration="0"/>
+		<max-hp value="600" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="0"/>
 		<armor-type value="leather"/>					

--- a/techs/megapack/factions/indian/upgrades/bullfood/bullfood.xml
+++ b/techs/megapack/factions/indian/upgrades/bullfood/bullfood.xml
@@ -11,7 +11,7 @@
 		<resource name="wood" amount="150"/>
 	</resource-requirements>
 	<effects/>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>

--- a/techs/megapack/factions/indian/upgrades/iron/iron.xml
+++ b/techs/megapack/factions/indian/upgrades/iron/iron.xml
@@ -11,7 +11,7 @@
 		<resource name="wood" amount="150"/>
 	</resource-requirements>
 	<effects/>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>

--- a/techs/megapack/factions/indian/upgrades/iron_advanced/iron_advanced.xml
+++ b/techs/megapack/factions/indian/upgrades/iron_advanced/iron_advanced.xml
@@ -17,7 +17,7 @@
 		<unit name="horseman"/>
 		<unit name="axe_thrower"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="40"/>

--- a/techs/megapack/factions/indian/upgrades/petroleum/petroleum.xml
+++ b/techs/megapack/factions/indian/upgrades/petroleum/petroleum.xml
@@ -13,7 +13,7 @@
 	<effects>
 		<unit name="fire_archer"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="1"/>
 	<attack-strenght value="40"/>

--- a/techs/megapack/factions/indian/upgrades/stables/stables.xml
+++ b/techs/megapack/factions/indian/upgrades/stables/stables.xml
@@ -11,7 +11,7 @@
 		<resource name="wood" amount="150"/>
 	</resource-requirements>
 	<effects/>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>

--- a/techs/megapack/factions/indian/upgrades/training_field/training_field.xml
+++ b/techs/megapack/factions/indian/upgrades/training_field/training_field.xml
@@ -13,7 +13,7 @@
 	<effects>
 		<unit name="roundtent"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>

--- a/techs/megapack/factions/magic/units/archmage/archmage.xml
+++ b/techs/megapack/factions/magic/units/archmage/archmage.xml
@@ -5,7 +5,7 @@
 		<size value="1"/>
 		<height value="2"/>
 		<max-hp value="450" regeneration="5" start-percentage="1.0" />
-		<max-ep value="3000" regeneration="30"/>
+		<max-ep value="3000" regeneration="30" start-percentage="1.0" />
 		<armor value="15"/>	
 		<armor-type value="leather"/>
 		<sight value="12"/>

--- a/techs/megapack/factions/magic/units/archmage/archmage.xml
+++ b/techs/megapack/factions/magic/units/archmage/archmage.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="450" regeneration="5"/>
+		<max-hp value="450" regeneration="5" start-percentage="1.0" />
 		<max-ep value="3000" regeneration="30"/>
 		<armor value="15"/>	
 		<armor-type value="leather"/>

--- a/techs/megapack/factions/magic/units/archmage_tower/archmage_tower.xml
+++ b/techs/megapack/factions/magic/units/archmage_tower/archmage_tower.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="11" />
-		<max-hp value="10000" regeneration="0"/>
+		<max-hp value="10000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="stone"/>

--- a/techs/megapack/factions/magic/units/battlemage/battlemage.xml
+++ b/techs/megapack/factions/magic/units/battlemage/battlemage.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="700" regeneration="3"/>
+		<max-hp value="700" regeneration="3" start-percentage="1.0" />
 		<max-ep value="500" regeneration="15"/>
 		<armor value="30"/>	
 		<armor-type value="leather"/>

--- a/techs/megapack/factions/magic/units/battlemage/battlemage.xml
+++ b/techs/megapack/factions/magic/units/battlemage/battlemage.xml
@@ -5,7 +5,7 @@
 		<size value="1"/>
 		<height value="2"/>
 		<max-hp value="700" regeneration="3" start-percentage="1.0" />
-		<max-ep value="500" regeneration="15"/>
+		<max-ep value="500" regeneration="15" start-percentage="1.0" />
 		<armor value="30"/>	
 		<armor-type value="leather"/>
 		<sight value="12"/>

--- a/techs/megapack/factions/magic/units/behemoth/behemoth.xml
+++ b/techs/megapack/factions/magic/units/behemoth/behemoth.xml
@@ -5,7 +5,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="2"/>
-		<max-hp value="5000" regeneration="5"/>
+		<max-hp value="5000" regeneration="5" start-percentage="1.0" />
 		<max-ep value="0" regeneration="0"/>
 		<armor value="50"/>	
 		<armor-type value="organic"/>

--- a/techs/megapack/factions/magic/units/daemon/daemon.xml
+++ b/techs/megapack/factions/magic/units/daemon/daemon.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="500" regeneration="0"/>
+		<max-hp value="500" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="10"/>	
 		<armor-type value="organic"/>

--- a/techs/megapack/factions/magic/units/dragon/dragon.xml
+++ b/techs/megapack/factions/magic/units/dragon/dragon.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="1"/>
-		<max-hp value="1400" regeneration="3"/>
+		<max-hp value="1400" regeneration="3" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="20"/>	
 		<armor-type value="organic"/>

--- a/techs/megapack/factions/magic/units/drake_rider/drake_rider.xml
+++ b/techs/megapack/factions/magic/units/drake_rider/drake_rider.xml
@@ -6,7 +6,7 @@
 		<size value="2"/>
 		<height value="4"/>
 		<max-hp value="1300" regeneration="2" start-percentage="1.0" />
-		<max-ep value="500" regeneration="5"/>
+		<max-ep value="500" regeneration="5" start-percentage="1.0" />
 		<armor value="50"/>	
 		<armor-type value="organic"/>
 		<sight value="10"/>

--- a/techs/megapack/factions/magic/units/drake_rider/drake_rider.xml
+++ b/techs/megapack/factions/magic/units/drake_rider/drake_rider.xml
@@ -5,7 +5,7 @@
 
 		<size value="2"/>
 		<height value="4"/>
-		<max-hp value="1300" regeneration="2"/>
+		<max-hp value="1300" regeneration="2" start-percentage="1.0" />
 		<max-ep value="500" regeneration="5"/>
 		<armor value="50"/>	
 		<armor-type value="organic"/>

--- a/techs/megapack/factions/magic/units/energy_source/energy_source.xml
+++ b/techs/megapack/factions/magic/units/energy_source/energy_source.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="2" />
 		<height value="2" />
-		<max-hp value="1400" regeneration="0"/>
+		<max-hp value="1400" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="stone"/>				

--- a/techs/megapack/factions/magic/units/evil_dragon/evil_dragon.xml
+++ b/techs/megapack/factions/magic/units/evil_dragon/evil_dragon.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="1"/>
-		<max-hp value="1700" regeneration="3"/>
+		<max-hp value="1700" regeneration="3" start-percentage="1.0" />
 		<max-ep value="1000" regeneration="200"/>
 		<armor value="20"/>	
 		<armor-type value="organic"/>

--- a/techs/megapack/factions/magic/units/evil_dragon/evil_dragon.xml
+++ b/techs/megapack/factions/magic/units/evil_dragon/evil_dragon.xml
@@ -5,7 +5,7 @@
 		<size value="2"/>
 		<height value="1"/>
 		<max-hp value="1700" regeneration="3" start-percentage="1.0" />
-		<max-ep value="1000" regeneration="200"/>
+		<max-ep value="1000" regeneration="200" start-percentage="1.0" />
 		<armor value="20"/>	
 		<armor-type value="organic"/>
 		<sight value="15"/>

--- a/techs/megapack/factions/magic/units/ghost_armor/ghost_armor.xml
+++ b/techs/megapack/factions/magic/units/ghost_armor/ghost_armor.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="900" regeneration="2"/>
+		<max-hp value="900" regeneration="2" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="30"/>	
 		<armor-type value="metal"/>

--- a/techs/megapack/factions/magic/units/golem/golem.xml
+++ b/techs/megapack/factions/magic/units/golem/golem.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="2"/>
-		<max-hp value="2000" regeneration="3"/>
+		<max-hp value="2000" regeneration="3" start-percentage="1.0" />
 		<max-ep value="1000" regeneration="10"/>
 		<armor value="45"/>	
 		<armor-type value="stone"/>

--- a/techs/megapack/factions/magic/units/golem/golem.xml
+++ b/techs/megapack/factions/magic/units/golem/golem.xml
@@ -5,7 +5,7 @@
 		<size value="2"/>
 		<height value="2"/>
 		<max-hp value="2000" regeneration="3" start-percentage="1.0" />
-		<max-ep value="1000" regeneration="10"/>
+		<max-ep value="1000" regeneration="10" start-percentage="1.0" />
 		<armor value="45"/>	
 		<armor-type value="stone"/>
 		<sight value="10"/>

--- a/techs/megapack/factions/magic/units/initiate/initiate.xml
+++ b/techs/megapack/factions/magic/units/initiate/initiate.xml
@@ -5,7 +5,7 @@
 		<size value="1"/>
 		<height value="2"/>
 		<max-hp value="450" regeneration="0" start-percentage="1.0" />
-		<max-ep value="50" regeneration="1"/>
+		<max-ep value="50" regeneration="1" start-percentage="1.0" />
 		<armor value="0"/>	
 		<armor-type value="leather"/>				
 		<sight value="9"/>

--- a/techs/megapack/factions/magic/units/initiate/initiate.xml
+++ b/techs/megapack/factions/magic/units/initiate/initiate.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="450" regeneration="0"/>
+		<max-hp value="450" regeneration="0" start-percentage="1.0" />
 		<max-ep value="50" regeneration="1"/>
 		<armor value="0"/>	
 		<armor-type value="leather"/>				

--- a/techs/megapack/factions/magic/units/library/library.xml
+++ b/techs/megapack/factions/magic/units/library/library.xml
@@ -3,7 +3,7 @@
 	<parameters>
 		<size value="4" />
 		<height value="2" />
-		<max-hp value="5000" regeneration="0"/>
+		<max-hp value="5000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="stone"/>				

--- a/techs/megapack/factions/magic/units/mage_tower/mage_tower.xml
+++ b/techs/megapack/factions/magic/units/mage_tower/mage_tower.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="5"/>
 		<height value="6"/>
-		<max-hp value="8000" regeneration="0"/>
+		<max-hp value="8000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="0"/>
 		<armor-type value="stone"/>				

--- a/techs/megapack/factions/magic/units/power_golem/power_golem.xml
+++ b/techs/megapack/factions/magic/units/power_golem/power_golem.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="2"/>
-		<max-hp value="2000" regeneration="3"/>
+		<max-hp value="2000" regeneration="3" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="45"/>	
 		<armor-type value="stone"/>

--- a/techs/megapack/factions/magic/units/summoner/summoner.xml
+++ b/techs/megapack/factions/magic/units/summoner/summoner.xml
@@ -5,7 +5,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="500" regeneration="4"/>
+		<max-hp value="500" regeneration="4" start-percentage="1.0" />
 		<max-ep value="500" regeneration="5"/>
 		<armor value="0"/>
 		<armor-type value="leather"/>					

--- a/techs/megapack/factions/magic/units/summoner/summoner.xml
+++ b/techs/megapack/factions/magic/units/summoner/summoner.xml
@@ -6,7 +6,7 @@
 		<size value="1"/>
 		<height value="2"/>
 		<max-hp value="500" regeneration="4" start-percentage="1.0" />
-		<max-ep value="500" regeneration="5"/>
+		<max-ep value="500" regeneration="5" start-percentage="1.0" />
 		<armor value="0"/>
 		<armor-type value="leather"/>					
 		<sight value="10"/>

--- a/techs/megapack/factions/magic/units/summoner_guild/summoner_guild.xml
+++ b/techs/megapack/factions/magic/units/summoner_guild/summoner_guild.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="3"/>
 		<height value="3"/>
-		<max-hp value="7000" regeneration="0"/>
+		<max-hp value="7000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="0"/>
 		<armor-type value="stone"/>		

--- a/techs/megapack/factions/magic/units/tower_of_souls/tower_of_souls.xml
+++ b/techs/megapack/factions/magic/units/tower_of_souls/tower_of_souls.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="2" />
 		<height value="3" />
-		<max-hp value="6000" regeneration="0"/>
+		<max-hp value="6000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="stone"/>				

--- a/techs/megapack/factions/magic/units/wicker_behemoth/wicker_behemoth.xml
+++ b/techs/megapack/factions/magic/units/wicker_behemoth/wicker_behemoth.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="2" />
 		<height value="2" />
-		<max-hp value="1400" regeneration="0"/>
+		<max-hp value="1400" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="wood"/>				

--- a/techs/megapack/factions/magic/upgrades/ancient_summoning/ancient_summoning.xml
+++ b/techs/megapack/factions/magic/upgrades/ancient_summoning/ancient_summoning.xml
@@ -14,7 +14,7 @@
 		<unit name="summoner"/>
 		<unit name="drake_rider"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="500"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>

--- a/techs/megapack/factions/magic/upgrades/dragon_call/dragon_call.xml
+++ b/techs/megapack/factions/magic/upgrades/dragon_call/dragon_call.xml
@@ -11,7 +11,7 @@
 		<resource name="gold" amount="250"/>
 	</resource-requirements>
 	<effects/>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>

--- a/techs/megapack/factions/magic/upgrades/energy_compression/energy_compression.xml
+++ b/techs/megapack/factions/magic/upgrades/energy_compression/energy_compression.xml
@@ -15,7 +15,7 @@
 		<unit name="drake_rider"/>
 		<unit name="archmage"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="500"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>

--- a/techs/megapack/factions/magic/upgrades/energy_sharpening/energy_sharpening.xml
+++ b/techs/megapack/factions/magic/upgrades/energy_sharpening/energy_sharpening.xml
@@ -17,7 +17,7 @@
 		<unit name="drake_rider"/>
 		<unit name="archmage"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="50"/>

--- a/techs/megapack/factions/magic/upgrades/golem_power/golem_power.xml
+++ b/techs/megapack/factions/magic/upgrades/golem_power/golem_power.xml
@@ -12,7 +12,7 @@
 	</resource-requirements>
 	<effects>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="1000"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>

--- a/techs/megapack/factions/magic/upgrades/hell_gate/hell_gate.xml
+++ b/techs/megapack/factions/magic/upgrades/hell_gate/hell_gate.xml
@@ -15,7 +15,7 @@
 		<unit name="ghost_armor"/>
 		<unit name="evil_dragon"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="20"/>

--- a/techs/megapack/factions/norsemen/units/archer/archer.xml
+++ b/techs/megapack/factions/norsemen/units/archer/archer.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="700" regeneration="1"/>
+		<max-hp value="700" regeneration="1" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="20"/>	
 		<armor-type value="leather"/>				
@@ -23,7 +23,8 @@
 		</fields>	
 		<properties/>
 		<light enabled="false"/>
-		<unit-requirements>			<unit name="farm"/>
+		<unit-requirements>
+			<unit name="farm"/>
 		</unit-requirements>
 		<upgrade-requirements/>
 		<resource-requirements>

--- a/techs/megapack/factions/norsemen/units/axe_thrower/axe_thrower.xml
+++ b/techs/megapack/factions/norsemen/units/axe_thrower/axe_thrower.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="700" regeneration="0"/>
+		<max-hp value="700" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="20"/>	
 		<armor-type value="leather"/>

--- a/techs/megapack/factions/norsemen/units/battleaxe/battleaxe.xml
+++ b/techs/megapack/factions/norsemen/units/battleaxe/battleaxe.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="700" regeneration="0"/>
+		<max-hp value="700" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="40"/>	
 		<armor-type value="leather"/>

--- a/techs/megapack/factions/norsemen/units/battleaxe_berzerk/battleaxe_berzerk.xml
+++ b/techs/megapack/factions/norsemen/units/battleaxe_berzerk/battleaxe_berzerk.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="700" regeneration="0"/>
+		<max-hp value="700" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="50"/>	
 		<armor-type value="leather"/>

--- a/techs/megapack/factions/norsemen/units/blacksmith/blacksmith.xml
+++ b/techs/megapack/factions/norsemen/units/blacksmith/blacksmith.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="4" />
 		<height value="2" />
-		<max-hp value="6000" regeneration="0"/>
+		<max-hp value="6000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="wood"/>		

--- a/techs/megapack/factions/norsemen/units/bone_tent/bone_tent.xml
+++ b/techs/megapack/factions/norsemen/units/bone_tent/bone_tent.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="4" />
 		<height value="2" />
-		<max-hp value="1000" regeneration="0"/>
+		<max-hp value="1000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="wood"/>				

--- a/techs/megapack/factions/norsemen/units/castle/castle.xml
+++ b/techs/megapack/factions/norsemen/units/castle/castle.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="5" />
 		<height value="6" />
-		<max-hp value="9000" regeneration="0"/>
+		<max-hp value="9000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="stone"/>				

--- a/techs/megapack/factions/norsemen/units/cow/cow.xml
+++ b/techs/megapack/factions/norsemen/units/cow/cow.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="1"/>
-		<max-hp value="500" regeneration="0"/>
+		<max-hp value="500" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="0"/>
 		<armor-type value="organic"/>					

--- a/techs/megapack/factions/norsemen/units/crossbow/crossbow.xml
+++ b/techs/megapack/factions/norsemen/units/crossbow/crossbow.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="4"/>
-		<max-hp value="1200" regeneration="3"/>
+		<max-hp value="1200" regeneration="3" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="15"/>
 		<armor-type value="wood"/>					

--- a/techs/megapack/factions/norsemen/units/cudgel_lady/cudgel_lady.xml
+++ b/techs/megapack/factions/norsemen/units/cudgel_lady/cudgel_lady.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="750" regeneration="1"/>
+		<max-hp value="750" regeneration="1" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="1"/>
 		<armor-type value="leather"/>					

--- a/techs/megapack/factions/norsemen/units/farm/farm.xml
+++ b/techs/megapack/factions/norsemen/units/farm/farm.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="4" />
 		<height value="2" />
-		<max-hp value="3000" regeneration="0"/>
+		<max-hp value="3000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="wood"/>				

--- a/techs/megapack/factions/norsemen/units/flyingvalkyrie/flyingvalkyrie.xml
+++ b/techs/megapack/factions/norsemen/units/flyingvalkyrie/flyingvalkyrie.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="2"/>
-		<max-hp value="1650" regeneration="3"/>
+		<max-hp value="1650" regeneration="3" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="30"/>	
 		<armor-type value="organic"/>

--- a/techs/megapack/factions/norsemen/units/house/house.xml
+++ b/techs/megapack/factions/norsemen/units/house/house.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="4" />
 		<height value="2" />
-		<max-hp value="3000" regeneration="0"/>
+		<max-hp value="3000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="wood"/>				

--- a/techs/megapack/factions/norsemen/units/med_bar/med_bar.xml
+++ b/techs/megapack/factions/norsemen/units/med_bar/med_bar.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="4" />
 		<height value="2" />
-		<max-hp value="6000" regeneration="0"/>
+		<max-hp value="6000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="stone"/>

--- a/techs/megapack/factions/norsemen/units/mistletree/mistletree.xml
+++ b/techs/megapack/factions/norsemen/units/mistletree/mistletree.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="2" />
 		<height value="6" />
-		<max-hp value="5000" regeneration="0"/>
+		<max-hp value="5000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="wood"/>		

--- a/techs/megapack/factions/norsemen/units/spearman/spearman.xml
+++ b/techs/megapack/factions/norsemen/units/spearman/spearman.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="700" regeneration="0"/>
+		<max-hp value="700" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="7"/>	
 		<armor-type value="leather"/>				
@@ -181,7 +181,7 @@
 			<move-skill value="charge_skill"/>
 			<attack-skill value="attack_skill"/>
 		</command>
-		
+		
 		<command>
 			<type value="attack_stopped"/>
 			<name value="hold_position"/>

--- a/techs/megapack/factions/norsemen/units/spearman_berzerk/spearman_berzerk.xml
+++ b/techs/megapack/factions/norsemen/units/spearman_berzerk/spearman_berzerk.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="700" regeneration="1"/>
+		<max-hp value="700" regeneration="1" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="20"/>	
 		<armor-type value="leather"/>				
@@ -182,7 +182,7 @@
 			<move-skill value="charge_skill"/>
 			<attack-skill value="attack_skill"/>
 		</command>
-		
+		
 		<command>
 			<type value="attack_stopped"/>
 			<name value="hold_position"/>

--- a/techs/megapack/factions/norsemen/units/swordman/swordman.xml
+++ b/techs/megapack/factions/norsemen/units/swordman/swordman.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="500" regeneration="1"/>
+		<max-hp value="500" regeneration="1" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="20"/>	
 		<armor-type value="leather"/>				
@@ -189,7 +189,7 @@
 			<move-skill value="charge_skill"/>
 			<attack-skill value="attack_skill"/>
 		</command>
-		
+		
 		<command>
 			<type value="attack_stopped"/>
 			<name value="hold_position"/>

--- a/techs/megapack/factions/norsemen/units/swordman_berzerk/swordman_berzerk.xml
+++ b/techs/megapack/factions/norsemen/units/swordman_berzerk/swordman_berzerk.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="600" regeneration="1"/>
+		<max-hp value="600" regeneration="1" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="35"/>	
 		<armor-type value="leather"/>				
@@ -192,7 +192,7 @@
 			<move-skill value="charge_skill"/>
 			<attack-skill value="attack_skill"/>
 		</command>
-		
+		
 		<command>
 			<type value="attack_stopped"/>
 			<name value="hold_position"/>

--- a/techs/megapack/factions/norsemen/units/thor/thor.xml
+++ b/techs/megapack/factions/norsemen/units/thor/thor.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="3"/>
-		<max-hp value="2000" regeneration="3"/>
+		<max-hp value="2000" regeneration="3" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="45"/>	
 		<armor-type value="stone"/>
@@ -158,7 +158,12 @@
 					<sound-file path="$COMMONDATAPATH/sounds/air_hit4.wav"/>
 				</sound>
 			</projectile>
-			<splash value="true">				<radius value="1"/>				<damage-all value="true"/>				<particle value="true" path="air_particle_splash.xml"/>			</splash>		</skill>
+			<splash value="true">
+				<radius value="1"/>
+				<damage-all value="true"/>
+				<particle value="true" path="air_particle_splash.xml"/>
+			</splash>
+		</skill>
 
 		<skill>
 			<type value="die"/>	

--- a/techs/megapack/factions/norsemen/units/thortotem/thortotem.xml
+++ b/techs/megapack/factions/norsemen/units/thortotem/thortotem.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="6"/>
-		<max-hp value="3000" regeneration="0"/>
+		<max-hp value="3000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="20"/>	
 		<armor-type value="wood"/>			

--- a/techs/megapack/factions/norsemen/units/thrull/thrull.xml
+++ b/techs/megapack/factions/norsemen/units/thrull/thrull.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="600" regeneration="0"/>
+		<max-hp value="600" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="0"/>
 		<armor-type value="leather"/>					

--- a/techs/megapack/factions/norsemen/units/valhalla/valhalla.xml
+++ b/techs/megapack/factions/norsemen/units/valhalla/valhalla.xml
@@ -3,7 +3,7 @@
 	<parameters>
 		<size value="4" />
 		<height value="4" />
-		<max-hp value="6000" regeneration="0"/>
+		<max-hp value="6000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="wood"/>		
@@ -142,5 +142,5 @@
 			<upgrade-skill value="upgrade_skill"/>
 			<produced-upgrade name="holy_valkyrie"/>
 		</command>	
-	</commands>
+	</commands>
 </unit>

--- a/techs/megapack/factions/norsemen/units/valkyrie/valkyrie.xml
+++ b/techs/megapack/factions/norsemen/units/valkyrie/valkyrie.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="800" regeneration="2"/>
+		<max-hp value="800" regeneration="2" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="80"/>	
 		<armor-type value="leather"/>				
@@ -215,7 +215,7 @@
 			<move-skill value="charge_skill"/>
 			<attack-skill value="attack_skill"/>
 		</command>
-		<command>
+		<command>
 			<type value="attack"/>
 			<name value="airattack"/>
 			<image path="images/air_attack.bmp"/>

--- a/techs/megapack/factions/norsemen/units/wild_sow/wild_sow.xml
+++ b/techs/megapack/factions/norsemen/units/wild_sow/wild_sow.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="700" regeneration="2"/>
+		<max-hp value="700" regeneration="2" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="3"/>	
 		<armor-type value="organic"/>

--- a/techs/megapack/factions/norsemen/upgrades/advanced_iron/advanced_iron.xml
+++ b/techs/megapack/factions/norsemen/upgrades/advanced_iron/advanced_iron.xml
@@ -16,7 +16,7 @@
 		<unit name="battleaxe_berzerk"/>
 		<unit name="axe_thrower"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="25"/>

--- a/techs/megapack/factions/norsemen/upgrades/arrow/arrow.xml
+++ b/techs/megapack/factions/norsemen/upgrades/arrow/arrow.xml
@@ -5,7 +5,8 @@
 	<image-cancel path="../advanced_iron/images/tech_upgrade_cancel.bmp"/>
 	<time value="300"/>
 	<unit-requirements>
-		<unit name="med_bar"/>	</unit-requirements>
+		<unit name="med_bar"/>
+	</unit-requirements>
 	<upgrade-requirements/>
 	<resource-requirements>
 		<resource name="gold" amount="200"/>
@@ -14,7 +15,7 @@
 	<effects>
 		<unit name="archer"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="25"/>

--- a/techs/megapack/factions/norsemen/upgrades/holy_valkyrie/holy_valkyrie.xml
+++ b/techs/megapack/factions/norsemen/upgrades/holy_valkyrie/holy_valkyrie.xml
@@ -13,7 +13,7 @@
 	</resource-requirements>
 	<effects>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>

--- a/techs/megapack/factions/norsemen/upgrades/iron/iron.xml
+++ b/techs/megapack/factions/norsemen/upgrades/iron/iron.xml
@@ -15,7 +15,7 @@
 		<unit name="axe_thrower"/>
 		<unit name="battleaxe"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="15"/>

--- a/techs/megapack/factions/norsemen/upgrades/med/med.xml
+++ b/techs/megapack/factions/norsemen/upgrades/med/med.xml
@@ -11,7 +11,7 @@
 		<resource name="wood" amount="150"/>
 	</resource-requirements>
 	<effects/>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>

--- a/techs/megapack/factions/norsemen/upgrades/root/root.xml
+++ b/techs/megapack/factions/norsemen/upgrades/root/root.xml
@@ -13,7 +13,7 @@
 	<effects>
 		<unit name="med_bar"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>

--- a/techs/megapack/factions/persian/units/blacksmith/blacksmith.xml
+++ b/techs/megapack/factions/persian/units/blacksmith/blacksmith.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="4" />
 		<height value="2" />
-		<max-hp value="6000" regeneration="0"/>
+		<max-hp value="6000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="stone"/>		

--- a/techs/megapack/factions/persian/units/elephant/elephant.xml
+++ b/techs/megapack/factions/persian/units/elephant/elephant.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="2"/>
-		<max-hp value="2700" regeneration="4"/>
+		<max-hp value="2700" regeneration="4" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="45"/>	
 		<armor-type value="leather"/>				
@@ -213,7 +213,7 @@
 			<move-skill value="move_skill"/>
 			<attack-skill value="attack_skill"/>
 		</command>
-		<command>
+		<command>
 			<type value="attack"/>
 			<name value="attack_arrow"/>
 			<image path="images/archer_attack.bmp"/>
@@ -222,7 +222,7 @@
 			<move-skill value="move_skill"/>
 			<attack-skill value="attack_arrow_skill"/>
 		</command>
-		
+		
 		<command>
 			<type value="attack_stopped"/>
 			<name value="hold_position"/>

--- a/techs/megapack/factions/persian/units/elephant_cage/elephant_cage.xml
+++ b/techs/megapack/factions/persian/units/elephant_cage/elephant_cage.xml
@@ -3,7 +3,7 @@
 	<parameters>
 		<size value="4" />
 		<height value="2" />
-		<max-hp value="6000" regeneration="0"/>
+		<max-hp value="6000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="metal"/>

--- a/techs/megapack/factions/persian/units/fakir/fakir.xml
+++ b/techs/megapack/factions/persian/units/fakir/fakir.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="700" regeneration="2"/>
+		<max-hp value="700" regeneration="2" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="7"/>	
 		<armor-type value="leather"/>				
@@ -187,7 +187,7 @@
 			<move-skill value="charge_skill"/>
 			<attack-skill value="attack_skill"/>
 		</command>
-		
+		
 		<command>
 			<type value="attack_stopped"/>
 			<name value="hold_position"/>

--- a/techs/megapack/factions/persian/units/farm/farm.xml
+++ b/techs/megapack/factions/persian/units/farm/farm.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="4" />
 		<height value="2" />
-		<max-hp value="3000" regeneration="0"/>
+		<max-hp value="3000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="wood"/>				

--- a/techs/megapack/factions/persian/units/flying_carpet/flying_carpet.xml
+++ b/techs/megapack/factions/persian/units/flying_carpet/flying_carpet.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="1"/>
-		<max-hp value="900" regeneration="2"/>
+		<max-hp value="900" regeneration="2" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="15"/>	
 		<armor-type value="organic"/>

--- a/techs/megapack/factions/persian/units/genie/genie.xml
+++ b/techs/megapack/factions/persian/units/genie/genie.xml
@@ -3,7 +3,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="3"/>
-		<max-hp value="700" regeneration="0"/>
+		<max-hp value="700" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="20"/>	
 		<armor-type value="leather"/>				

--- a/techs/megapack/factions/persian/units/house/house.xml
+++ b/techs/megapack/factions/persian/units/house/house.xml
@@ -3,7 +3,7 @@
 	<parameters>
 		<size value="4" />
 		<height value="4" />
-		<max-hp value="1400" regeneration="0"/>
+		<max-hp value="1400" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="stone"/>		

--- a/techs/megapack/factions/persian/units/magician/magician.xml
+++ b/techs/megapack/factions/persian/units/magician/magician.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="3"/>
-		<max-hp value="900" regeneration="3"/>
+		<max-hp value="900" regeneration="3" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="20"/>	
 		<armor-type value="leather"/>				
@@ -276,7 +276,7 @@
                                 <unit name="fakir"/>					
 			</repaired-units>		
 		</command>
-		
+		
 		<command>
 			<type value="attack_stopped"/>
 			<name value="hold_position"/>

--- a/techs/megapack/factions/persian/units/minaret/minaret.xml
+++ b/techs/megapack/factions/persian/units/minaret/minaret.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="6"/>
-		<max-hp value="7000" regeneration="0"/>
+		<max-hp value="7000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="20"/>	
 		<armor-type value="wood"/>			

--- a/techs/megapack/factions/persian/units/palace/palace.xml
+++ b/techs/megapack/factions/persian/units/palace/palace.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="5" />
 		<height value="2" />
-		<max-hp value="9000" regeneration="0"/>
+		<max-hp value="9000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="stone"/>				

--- a/techs/megapack/factions/persian/units/sheep/sheep.xml
+++ b/techs/megapack/factions/persian/units/sheep/sheep.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="1"/>
-		<max-hp value="500" regeneration="0"/>
+		<max-hp value="500" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="0"/>
 		<armor-type value="organic"/>					

--- a/techs/megapack/factions/persian/units/snake_basket/snake_basket.xml
+++ b/techs/megapack/factions/persian/units/snake_basket/snake_basket.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="1"/>
-		<max-hp value="7000" regeneration="0"/>
+		<max-hp value="7000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="100" regeneration="0"/>
 		<armor value="20"/>	
 		<armor-type value="wood"/>			

--- a/techs/megapack/factions/persian/units/swordman/swordman.xml
+++ b/techs/megapack/factions/persian/units/swordman/swordman.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="900" regeneration="2"/>
+		<max-hp value="900" regeneration="2" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="25"/>	
 		<armor-type value="metal"/>				

--- a/techs/megapack/factions/persian/units/temple/temple.xml
+++ b/techs/megapack/factions/persian/units/temple/temple.xml
@@ -3,7 +3,7 @@
 	<parameters>
 		<size value="4" />
 		<height value="2" />
-		<max-hp value="6000" regeneration="0"/>
+		<max-hp value="6000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="wood"/>

--- a/techs/megapack/factions/persian/units/tent/tent.xml
+++ b/techs/megapack/factions/persian/units/tent/tent.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="4" />
 		<height value="2" />
-		<max-hp value="3000" regeneration="0"/>
+		<max-hp value="3000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="leather"/>		

--- a/techs/megapack/factions/persian/units/worker/worker.xml
+++ b/techs/megapack/factions/persian/units/worker/worker.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="600" regeneration="0"/>
+		<max-hp value="600" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="0"/>
 		<armor-type value="leather"/>					

--- a/techs/megapack/factions/persian/upgrades/corn_and_wicker/corn_and_wicker.xml
+++ b/techs/megapack/factions/persian/upgrades/corn_and_wicker/corn_and_wicker.xml
@@ -15,7 +15,7 @@
 	</resource-requirements>
 	<effects>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>

--- a/techs/megapack/factions/persian/upgrades/magic_level_1/magic_level_1.xml
+++ b/techs/megapack/factions/persian/upgrades/magic_level_1/magic_level_1.xml
@@ -12,7 +12,7 @@
 	</resource-requirements>
 	<effects>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>

--- a/techs/megapack/factions/persian/upgrades/magic_level_2/magic_level_2.xml
+++ b/techs/megapack/factions/persian/upgrades/magic_level_2/magic_level_2.xml
@@ -16,7 +16,7 @@
 		<unit name="genie"/>
 		<unit name="magician"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="40"/>

--- a/techs/megapack/factions/persian/upgrades/nails/nails.xml
+++ b/techs/megapack/factions/persian/upgrades/nails/nails.xml
@@ -14,7 +14,7 @@
 	<effects>
 		<unit name="fakir"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="20"/>

--- a/techs/megapack/factions/persian/upgrades/shield/shield.xml
+++ b/techs/megapack/factions/persian/upgrades/shield/shield.xml
@@ -15,7 +15,7 @@
 		<unit name="princess"/>
 		<unit name="flying_carpet"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>

--- a/techs/megapack/factions/persian/upgrades/weapons/weapons.xml
+++ b/techs/megapack/factions/persian/upgrades/weapons/weapons.xml
@@ -19,7 +19,7 @@
 		<unit name="snake_basket"/>
 		<unit name="flying_carpet"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="40"/>

--- a/techs/megapack/factions/romans/units/archer/archer.xml
+++ b/techs/megapack/factions/romans/units/archer/archer.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="3"/>
-		<max-hp value="650" regeneration="0"/>
+		<max-hp value="650" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="10"/>	
 		<armor-type value="metal"/>				

--- a/techs/megapack/factions/romans/units/ballista/ballista.xml
+++ b/techs/megapack/factions/romans/units/ballista/ballista.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="3"/>
-		<max-hp value="1500" regeneration="1"/>
+		<max-hp value="1500" regeneration="1" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="25"/>	
 		<armor-type value="wood"/>				

--- a/techs/megapack/factions/romans/units/battering_ram/battering_ram.xml
+++ b/techs/megapack/factions/romans/units/battering_ram/battering_ram.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="3"/>
 		<height value="3"/>
-		<max-hp value="2700" regeneration="4"/>
+		<max-hp value="2700" regeneration="4" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="45"/>	
 		<armor-type value="leather"/>				

--- a/techs/megapack/factions/romans/units/blacksmith_shop/blacksmith_shop.xml
+++ b/techs/megapack/factions/romans/units/blacksmith_shop/blacksmith_shop.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="4" />
 		<height value="2" />
-		<max-hp value="5500" regeneration="0"/>
+		<max-hp value="5500" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="stone"/>		

--- a/techs/megapack/factions/romans/units/catapult/catapult.xml
+++ b/techs/megapack/factions/romans/units/catapult/catapult.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="4"/>
-		<max-hp value="1800" regeneration="1"/>
+		<max-hp value="1800" regeneration="1" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="0"/>
 		<armor-type value="wood"/>					

--- a/techs/megapack/factions/romans/units/cavalry/cavalry.xml
+++ b/techs/megapack/factions/romans/units/cavalry/cavalry.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="2"/>
-		<max-hp value="1300" regeneration="0"/>
+		<max-hp value="1300" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="30"/>	
 		<armor-type value="metal"/>

--- a/techs/megapack/factions/romans/units/cow/cow.xml
+++ b/techs/megapack/factions/romans/units/cow/cow.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="1"/>
-		<max-hp value="500" regeneration="0"/>
+		<max-hp value="500" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="0"/>
 		<armor-type value="organic"/>					

--- a/techs/megapack/factions/romans/units/eagle_pillar/eagle_pillar.xml
+++ b/techs/megapack/factions/romans/units/eagle_pillar/eagle_pillar.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="4"/>
-		<max-hp value="4000" regeneration="1"/>
+		<max-hp value="4000" regeneration="1" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="15"/>	
 		<armor-type value="stone"/>			

--- a/techs/megapack/factions/romans/units/fire_archer/fire_archer.xml
+++ b/techs/megapack/factions/romans/units/fire_archer/fire_archer.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="1000" regeneration="1"/>
+		<max-hp value="1000" regeneration="1" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="12"/>	
 		<armor-type value="leather"/>				

--- a/techs/megapack/factions/romans/units/forum/forum.xml
+++ b/techs/megapack/factions/romans/units/forum/forum.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="6" />
 		<height value="2" />
-		<max-hp value="11000" regeneration="0"/>
+		<max-hp value="11000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="stone"/>				

--- a/techs/megapack/factions/romans/units/general/general.xml
+++ b/techs/megapack/factions/romans/units/general/general.xml
@@ -72,7 +72,7 @@
 				<allow-multiple-boosts value="false" />
 				<radius value="10"/>
                         	<target value="faction"></target>
-				<max-hp value="0"/>
+				<max-hp value="0" start-percentage="1.0" />
 				<max-ep value="0"/>
 				<sight value="1"/>
 				<attack-strenght value="35" value-percent-multiplier="true"/>
@@ -99,7 +99,7 @@
 				<allow-multiple-boosts value="false" />
 				<radius value="10"/>
                         	<target value="faction"></target>
-				<max-hp value="0"/>
+				<max-hp value="0" start-percentage="1.0" />
 				<max-ep value="0"/>
 				<sight value="1"/>
 				<attack-strenght value="35" value-percent-multiplier="true"/>
@@ -142,7 +142,7 @@
 				<allow-multiple-boosts value="false" />
 				<radius value="10"/>
                         	<target value="faction"></target>
-				<max-hp value="0"/>
+				<max-hp value="0" start-percentage="1.0" />
 				<max-ep value="0"/>
 				<sight value="1"/>
 				<attack-strenght value="35" value-percent-multiplier="true"/>
@@ -194,7 +194,7 @@
 				<allow-multiple-boosts value="false" />
 				<radius value="10"/>
                         	<target value="faction"></target>
-				<max-hp value="0"/>
+				<max-hp value="0" start-percentage="1.0" />
 				<max-ep value="0"/>
 				<sight value="1"/>
 				<attack-strenght value="35" value-percent-multiplier="true"/>

--- a/techs/megapack/factions/romans/units/gladiator_school/gladiator_school.xml
+++ b/techs/megapack/factions/romans/units/gladiator_school/gladiator_school.xml
@@ -3,7 +3,7 @@
 	<parameters>
 		<size value="4" />
 		<height value="2" />
-		<max-hp value="4500" regeneration="0"/>
+		<max-hp value="4500" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="wood"/>

--- a/techs/megapack/factions/romans/units/guard_tower/guard_tower.xml
+++ b/techs/megapack/factions/romans/units/guard_tower/guard_tower.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="6"/>
-		<max-hp value="8500" regeneration="0"/>
+		<max-hp value="8500" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="20"/>	
 		<armor-type value="stone"/>			

--- a/techs/megapack/factions/romans/units/military_camp/military_camp.xml
+++ b/techs/megapack/factions/romans/units/military_camp/military_camp.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="4" />
 		<height value="2" />
-		<max-hp value="8000" regeneration="0"/>
+		<max-hp value="8000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="stone"/>				

--- a/techs/megapack/factions/romans/units/slave/slave.xml
+++ b/techs/megapack/factions/romans/units/slave/slave.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="650" regeneration="0"/>
+		<max-hp value="650" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="0"/>
 		<armor-type value="leather"/>					

--- a/techs/megapack/factions/romans/units/spearman/spearman.xml
+++ b/techs/megapack/factions/romans/units/spearman/spearman.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="700" regeneration="0"/>
+		<max-hp value="700" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="16"/>	
 		<armor-type value="metal"/>				

--- a/techs/megapack/factions/romans/units/temple/temple.xml
+++ b/techs/megapack/factions/romans/units/temple/temple.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="4" />
 		<height value="2" />
-		<max-hp value="9000" regeneration="0"/>
+		<max-hp value="9000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="stone"/>				

--- a/techs/megapack/factions/romans/units/training_camp/training_camp.xml
+++ b/techs/megapack/factions/romans/units/training_camp/training_camp.xml
@@ -3,7 +3,7 @@
 	<parameters>
 		<size value="5" />
 		<height value="2" />
-		<max-hp value="4500" regeneration="0"/>
+		<max-hp value="4500" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="wood"/>

--- a/techs/megapack/factions/romans/units/tribune/tribune.xml
+++ b/techs/megapack/factions/romans/units/tribune/tribune.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="2"/>
-		<max-hp value="1600" regeneration="0"/>
+		<max-hp value="1600" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="50"/>	
 		<armor-type value="metal"/>

--- a/techs/megapack/factions/romans/upgrades/advanced_architecture/advanced_architecture.xml
+++ b/techs/megapack/factions/romans/upgrades/advanced_architecture/advanced_architecture.xml
@@ -11,7 +11,7 @@
 		<resource name="gold" amount="200"/>
 	</resource-requirements>
 	<effects/>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>

--- a/techs/megapack/factions/romans/upgrades/bless_of_minerva/bless_of_minerva.xml
+++ b/techs/megapack/factions/romans/upgrades/bless_of_minerva/bless_of_minerva.xml
@@ -15,7 +15,7 @@
 		<unit name="archer"/>
 		<unit name="ballista"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="1"/>
 	<attack-strenght value="8"/>

--- a/techs/megapack/factions/romans/upgrades/enlarge_shields/enlarge_shields.xml
+++ b/techs/megapack/factions/romans/upgrades/enlarge_shields/enlarge_shields.xml
@@ -21,7 +21,7 @@
 		<unit name="tribune"/>
 		<unit name="spearman"/>
 	</effects>
-	<max-hp value="30"/>
+	<max-hp value="30" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>

--- a/techs/megapack/factions/romans/upgrades/formations/formations.xml
+++ b/techs/megapack/factions/romans/upgrades/formations/formations.xml
@@ -11,7 +11,7 @@
 		<resource name="gold" amount="250"/>
 	</resource-requirements>
 	<effects/>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>

--- a/techs/megapack/factions/romans/upgrades/jupiter/jupiter.xml
+++ b/techs/megapack/factions/romans/upgrades/jupiter/jupiter.xml
@@ -18,7 +18,7 @@
 		<unit name="guard"/>
 		<unit name="axe_man"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="1"/>
 	<attack-strenght value="6"/>

--- a/techs/megapack/factions/romans/upgrades/reinforce_armor/reinforce_armor.xml
+++ b/techs/megapack/factions/romans/upgrades/reinforce_armor/reinforce_armor.xml
@@ -18,7 +18,7 @@
 		<unit name="general"/>
 		<unit name="tribune"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>

--- a/techs/megapack/factions/romans/upgrades/sharpen_points/sharpen_points.xml
+++ b/techs/megapack/factions/romans/upgrades/sharpen_points/sharpen_points.xml
@@ -19,7 +19,7 @@
 		<unit name="gladiator"/>
 		<unit name="turtle_formation"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="20"/>

--- a/techs/megapack/factions/romans/upgrades/sign_of_mars/sign_of_mars.xml
+++ b/techs/megapack/factions/romans/upgrades/sign_of_mars/sign_of_mars.xml
@@ -17,7 +17,7 @@
 		<unit name="wartime_mechanic"/>
 		<unit name="battering_ram"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="1"/>
 	<attack-strenght value="10"/>

--- a/techs/megapack/factions/romans/upgrades/strengthen_swords/strengthen_swords.xml
+++ b/techs/megapack/factions/romans/upgrades/strengthen_swords/strengthen_swords.xml
@@ -15,7 +15,7 @@
 		<unit name="general"/>
 		<unit name="tribune"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="20"/>

--- a/techs/megapack/factions/romans/upgrades/training_field/training_field.xml
+++ b/techs/megapack/factions/romans/upgrades/training_field/training_field.xml
@@ -13,7 +13,7 @@
 	<effects>
 		<unit name="training_camp"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>

--- a/techs/megapack/factions/tech/units/aerodrome/aerodrome.xml
+++ b/techs/megapack/factions/tech/units/aerodrome/aerodrome.xml
@@ -3,7 +3,7 @@
 	<parameters>
 		<size value="4" />
 		<height value="4" />
-		<max-hp value="6000" regeneration="0"/>
+		<max-hp value="6000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="wood"/>		

--- a/techs/megapack/factions/tech/units/air_ballista/air_ballista.xml
+++ b/techs/megapack/factions/tech/units/air_ballista/air_ballista.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="3"/>
-		<max-hp value="3000" regeneration="5"/>
+		<max-hp value="3000" regeneration="5" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="20"/>	
 		<armor-type value="wood"/>				

--- a/techs/megapack/factions/tech/units/airship/airship.xml
+++ b/techs/megapack/factions/tech/units/airship/airship.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="3"/>
 		<height value="1"/>
-		<max-hp value="2200" regeneration="2"/>
+		<max-hp value="2200" regeneration="2" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="20"/>	
 		<armor-type value="leather"/>

--- a/techs/megapack/factions/tech/units/archer/archer.xml
+++ b/techs/megapack/factions/tech/units/archer/archer.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="3"/>
-		<max-hp value="700" regeneration="0"/>
+		<max-hp value="700" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="20"/>	
 		<armor-type value="leather"/>				

--- a/techs/megapack/factions/tech/units/barracks/barracks.xml
+++ b/techs/megapack/factions/tech/units/barracks/barracks.xml
@@ -3,7 +3,7 @@
 	<parameters>
 		<size value="4" />
 		<height value="2" />
-		<max-hp value="6000" regeneration="0"/>
+		<max-hp value="6000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="stone"/>

--- a/techs/megapack/factions/tech/units/battle_machine/battle_machine.xml
+++ b/techs/megapack/factions/tech/units/battle_machine/battle_machine.xml
@@ -5,7 +5,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="2"/>
-		<max-hp value="2500" regeneration="1"/>
+		<max-hp value="2500" regeneration="1" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="45"/>	
 		<armor-type value="wood"/>

--- a/techs/megapack/factions/tech/units/blacksmith/blacksmith.xml
+++ b/techs/megapack/factions/tech/units/blacksmith/blacksmith.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="4" />
 		<height value="2" />
-		<max-hp value="6000" regeneration="0"/>
+		<max-hp value="6000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="wood"/>		

--- a/techs/megapack/factions/tech/units/castle/castle.xml
+++ b/techs/megapack/factions/tech/units/castle/castle.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="5" />
 		<height value="2" />
-		<max-hp value="9000" regeneration="0"/>
+		<max-hp value="9000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="stone"/>				

--- a/techs/megapack/factions/tech/units/catapult/catapult.xml
+++ b/techs/megapack/factions/tech/units/catapult/catapult.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="4"/>
-		<max-hp value="1500" regeneration="1"/>
+		<max-hp value="1500" regeneration="1" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="10"/>
 		<armor-type value="wood"/>					

--- a/techs/megapack/factions/tech/units/cow/cow.xml
+++ b/techs/megapack/factions/tech/units/cow/cow.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="1"/>
-		<max-hp value="500" regeneration="0"/>
+		<max-hp value="500" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="0"/>
 		<armor-type value="organic"/>					

--- a/techs/megapack/factions/tech/units/defense_tower/defense_tower.xml
+++ b/techs/megapack/factions/tech/units/defense_tower/defense_tower.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="6"/>
-		<max-hp value="7000" regeneration="0"/>
+		<max-hp value="7000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="20"/>	
 		<armor-type value="wood"/>			

--- a/techs/megapack/factions/tech/units/farm/farm.xml
+++ b/techs/megapack/factions/tech/units/farm/farm.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="4" />
 		<height value="2" />
-		<max-hp value="3000" regeneration="0"/>
+		<max-hp value="3000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="wood"/>				

--- a/techs/megapack/factions/tech/units/horseman/horseman.xml
+++ b/techs/megapack/factions/tech/units/horseman/horseman.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="2"/>
-		<max-hp value="1400" regeneration="0"/>
+		<max-hp value="1400" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="30"/>	
 		<armor-type value="leather"/>

--- a/techs/megapack/factions/tech/units/ornithopter/ornithopter.xml
+++ b/techs/megapack/factions/tech/units/ornithopter/ornithopter.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="2"/>
 		<height value="1"/>
-		<max-hp value="900" regeneration="2"/>
+		<max-hp value="900" regeneration="2" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="15"/>	
 		<armor-type value="organic"/>

--- a/techs/megapack/factions/tech/units/pig/pig.xml
+++ b/techs/megapack/factions/tech/units/pig/pig.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="1"/>
-		<max-hp value="300" regeneration="0"/>
+		<max-hp value="300" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="0"/>
 		<armor-type value="organic"/>					

--- a/techs/megapack/factions/tech/units/swordman/swordman.xml
+++ b/techs/megapack/factions/tech/units/swordman/swordman.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="700" regeneration="0"/>
+		<max-hp value="700" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="20"/>	
 		<armor-type value="leather"/>				

--- a/techs/megapack/factions/tech/units/technician/technician.xml
+++ b/techs/megapack/factions/tech/units/technician/technician.xml
@@ -5,7 +5,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="550" regeneration="0"/>
+		<max-hp value="550" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="0"/>
 		<armor-type value="leather"/>					

--- a/techs/megapack/factions/tech/units/technodrome/technodrome.xml
+++ b/techs/megapack/factions/tech/units/technodrome/technodrome.xml
@@ -4,7 +4,7 @@
 	<parameters>
 		<size value="4" />
 		<height value="4" />
-		<max-hp value="6000" regeneration="0"/>
+		<max-hp value="6000" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0" />
 		<armor value="0" />
 		<armor-type value="wood"/>		

--- a/techs/megapack/factions/tech/units/worker/worker.xml
+++ b/techs/megapack/factions/tech/units/worker/worker.xml
@@ -7,7 +7,7 @@
 	<parameters>
 		<size value="1"/>
 		<height value="2"/>
-		<max-hp value="600" regeneration="0"/>
+		<max-hp value="600" regeneration="0" start-percentage="1.0" />
 		<max-ep value="0"/>
 		<armor value="0"/>
 		<armor-type value="leather"/>					

--- a/techs/megapack/factions/tech/upgrades/advanced_architecture/advanced_architecture.xml
+++ b/techs/megapack/factions/tech/upgrades/advanced_architecture/advanced_architecture.xml
@@ -11,7 +11,7 @@
 		<resource name="gold" amount="200"/>
 	</resource-requirements>
 	<effects/>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>

--- a/techs/megapack/factions/tech/upgrades/blade_weapons/blade_weapons.xml
+++ b/techs/megapack/factions/tech/upgrades/blade_weapons/blade_weapons.xml
@@ -14,7 +14,7 @@
 		<unit name="swordman"/>
 		<unit name="guard"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="20"/>

--- a/techs/megapack/factions/tech/upgrades/piercing_weapons/piercing_weapons.xml
+++ b/techs/megapack/factions/tech/upgrades/piercing_weapons/piercing_weapons.xml
@@ -15,7 +15,7 @@
 		<unit name="archer"/>
 		<unit name="horseman"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="20"/>

--- a/techs/megapack/factions/tech/upgrades/robotics/robotics.xml
+++ b/techs/megapack/factions/tech/upgrades/robotics/robotics.xml
@@ -13,7 +13,7 @@
 	<effects>
 		<unit name="barracks"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>

--- a/techs/megapack/factions/tech/upgrades/shield_level_1/shield_level_1.xml
+++ b/techs/megapack/factions/tech/upgrades/shield_level_1/shield_level_1.xml
@@ -15,7 +15,7 @@
 		<unit name="guard"/>
 		<unit name="horseman"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>

--- a/techs/megapack/factions/tech/upgrades/shield_level_2/shield_level_2.xml
+++ b/techs/megapack/factions/tech/upgrades/shield_level_2/shield_level_2.xml
@@ -17,7 +17,7 @@
 		<unit name="guard"/>
 		<unit name="horseman"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>

--- a/techs/megapack/factions/tech/upgrades/stables/stables.xml
+++ b/techs/megapack/factions/tech/upgrades/stables/stables.xml
@@ -11,7 +11,7 @@
 		<resource name="wood" amount="150"/>
 	</resource-requirements>
 	<effects/>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>

--- a/techs/megapack/factions/tech/upgrades/training_field/training_field.xml
+++ b/techs/megapack/factions/tech/upgrades/training_field/training_field.xml
@@ -13,7 +13,7 @@
 	<effects>
 		<unit name="barracks"/>
 	</effects>
-	<max-hp value="0"/>
+	<max-hp value="0" start-percentage="1.0" />
 	<max-ep value="0"/>
 	<sight value="0"/>
 	<attack-strenght value="0"/>


### PR DESCRIPTION
This differs in two ways:

1. Units that have upgrades that boost health take effect from that upgrade immediately, instead of having to regenerate the difference.
2. Units with EP start with full EP instead of none. Thus, a newly created mage can head straight into battle instead of having to wait for their EP to regenerate. This may impact balance. On one hand, EP using units were at a disadvantage because of this need to wait. On the other hand, this makes them slightly more potent, off the bat. It shouldn't make a difference when attacking, though, and only a minor difference for defenders.