### PR TITLE
norse/thrall.xml:move farm build command

### DIFF
--- a/techs/megapack/factions/norsemen/units/thrall/thrall.xml
+++ b/techs/megapack/factions/norsemen/units/thrall/thrall.xml
@@ -239,11 +239,11 @@
 			<move-skill value="move_skill"/>
 			<build-skill value="build_skill"/>
 			<buildings>
-                                <building name="house"/>
+				<building name="farm"/>
+				<building name="house"/>
 				<building name="mead_bar"/>
 				<building name="bone_tent"/>
 				<building name="blacksmith"/>
-				<building name="farm"/>
 				<building name="valhalla"/>
 				<building name="thor_totem"/>
 				<building name="castle"/>


### PR DESCRIPTION
Right now the build icon for the farm is on the second row of the thrall
build menu, 4th in the list. This puts it first, for a slightly improved UX, and also makes it more more consistent (the build menu for the tech faction shows farm, then barracks).

![image](https://user-images.githubusercontent.com/16764864/52909804-cb89f080-3253-11e9-8bb7-2d96bd5c99c5.png)
